### PR TITLE
Remove the word should from spec descriptions

### DIFF
--- a/spec/zero_push_client_spec.rb
+++ b/spec/zero_push_client_spec.rb
@@ -17,13 +17,13 @@ describe ZeroPush::Client do
   end
 
   describe 'compatibility' do
-    it 'should use url_encoding if `info` or `data` params are strings' do
+    it 'uses url_encoding if `info` or `data` params are strings' do
       request = stub_request(:post, "https://api.zeropush.com/notify").
         with(body: {"info" => "{\"a\":1}"}, headers: {'Content-Type'=>'application/x-www-form-urlencoded'}).to_return(status: 200)
       client.notify(info: JSON.dump({a: 1}))
       assert_request_requested request
     end
-    it 'should use JSON encoding if `info` or `data` params are hashes' do
+    it 'uses JSON encoding if `info` or `data` params are hashes' do
       request = stub_request(:post, "https://api.zeropush.com/notify").
         with(body: '{"info":{"a":1}}', headers: {'Content-Type' => 'application/json'}).to_return(status: 200)
       client.notify(info: {a: 1})
@@ -32,14 +32,14 @@ describe ZeroPush::Client do
   end
 
   describe '#http' do
-    it 'should instantiate a default http client' do
+    it 'instantiates a default http client' do
       client.http.must_be_instance_of Faraday::Connection
       client.http.headers['Authorization'].must_equal 'Token token="test-token"'
     end
   end
 
   describe '#verify_credentials' do
-    it 'should verify credentials successfully' do
+    it 'verifies credentials successfully' do
       stub_request(:get, "https://api.zeropush.com/verify_credentials").
         with(headers: {'Authorization'=>'Token token="test-token"'}).
         to_return(status: 200, body: '{"message": "authenticated"}', headers: {'Content-Type' => 'application/json'})
@@ -47,7 +47,7 @@ describe ZeroPush::Client do
       client.verify_credentials.must_equal true
     end
 
-    it 'should fail to verify credentials' do
+    it 'fails to verify credentials' do
       stub_request(:get, "https://api.zeropush.com/verify_credentials").
         with(headers: {'Authorization'=>'Token token="not a valid token"'}).
         to_return(status: 401, body: '{"error": "unauthorized"}', headers: {'Content-Type' => 'application/json'})
@@ -71,11 +71,11 @@ describe ZeroPush::Client do
 
     let(:response){client.notify(device_tokens: [device_token], alert: 'hi')}
 
-    it 'should return a hash' do
+    it 'returns a hash' do
       response.body.class.must_equal Hash
     end
 
-    it 'should construct the request' do
+    it 'constructs the request' do
       response.body['sent_count'].must_equal 1
       response.body['inactive_tokens'].must_equal []
     end
@@ -83,11 +83,11 @@ describe ZeroPush::Client do
 
   describe '#register' do
     describe 'without a channel parameter' do
-      it 'should return a hash' do
+      it 'returns a hash' do
         client.register(device_token).body.class.must_equal Hash
       end
 
-      it 'should register the device' do
+      it 'registers the device' do
         client.register(device_token).body['message'].must_equal 'ok'
       end
     end
@@ -99,11 +99,11 @@ describe ZeroPush::Client do
                headers: {'Authorization'=>'Token token="test-token"', 'Content-Type'=>'application/json'}).
           to_return(status: 200, body: '{"message":"ok"}', headers: {'Content-Type'=>'application/json'})
       end
-      it 'should return a hash' do
+      it 'returns a hash' do
         client.register(device_token, 'foo').body.class.must_equal Hash
       end
 
-      it 'should register the device' do
+      it 'registers the device' do
         client.register(device_token, 'foo').body['message'].must_equal 'ok'
       end
     end
@@ -120,11 +120,11 @@ describe ZeroPush::Client do
           to_return(status: 200, body: '{"message":"ok"}', headers: {'Content-Type' => 'application/json'})
       end
 
-      it 'should return a hash' do
+      it 'returns a hash' do
         client.unregister(device_token).body.class.must_equal Hash
       end
 
-      it 'should unregister the device' do
+      it 'unregisters the device' do
         client.unregister(device_token).body['message'].must_equal 'ok'
       end
     end
@@ -139,11 +139,11 @@ describe ZeroPush::Client do
 
     let(:response){client.subscribe(device_token, 'foo_channel')}
 
-    it 'should return a hash' do
+    it 'returns a hash' do
       response.body.class.must_equal Hash
     end
 
-    it 'should subscribe a device to a channel' do
+    it 'subscribes a device to a channel' do
       response.body['device_token'].must_equal device_token
       response.body['channels'].must_include 'foo_channel'
     end
@@ -157,11 +157,11 @@ describe ZeroPush::Client do
 
     let(:response){client.unsubscribe(device_token, 'foo_channel')}
 
-    it 'should return a hash' do
+    it 'returns a hash' do
       response.body.class.must_equal Hash
     end
 
-    it 'should subscribe a device to a channel' do
+    it 'subscribes a device to a channel' do
       response.body['device_token'].must_equal device_token
       response.body['channels'].wont_include 'foo_channel'
     end
@@ -175,15 +175,15 @@ describe ZeroPush::Client do
     end
     let(:response){client.broadcast(alert:'hi')}
 
-    it 'should return a hash' do
+    it 'returns a hash' do
       response.body.class.must_equal Hash
     end
 
-    it 'should broadcast a notification to all the devices' do
+    it 'broadcasts a notification to all the devices' do
       response.body['sent_count'].must_equal 10
     end
 
-    it 'should use json encoding for custom data' do
+    it 'uses json encoding for custom data' do
       request = stub_request(:post, "https://api.zeropush.com/broadcast").
         with(body: '{"data":{"alert":"hi","user_id":5}}', headers: {'Content-Type'=>'application/json'}).to_return(status: 200)
       client.broadcast(data: {alert: "hi", user_id: 5})
@@ -200,11 +200,11 @@ describe ZeroPush::Client do
 
     let(:response){client.set_badge(device_token, 10)}
 
-    it 'should return a hash' do
+    it 'returns a hash' do
       response.body.class.must_equal Hash
     end
 
-    it 'should set the device\'s badge' do
+    it 'sets the device\'s badge' do
       response.body['message'].must_equal 'ok'
     end
   end
@@ -217,11 +217,11 @@ describe ZeroPush::Client do
         to_return(status: 200, body: '[{"device_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","marked_inactive_at": "2013-03-11T16:25:14-04:00"}]', headers: {'Content-Type'=>'application/json'})
     end
 
-    it 'should return an array' do
+    it 'returns an array' do
       response.body.class.must_equal Array
     end
 
-    it 'should get a list of inactive tokens' do
+    it 'gets a list of inactive tokens' do
       response.body.count.must_equal 1
     end
   end
@@ -232,10 +232,10 @@ describe ZeroPush::Client do
       stub_request(:get, "https://api.zeropush.com/devices?page=1").
         to_return(status: 200, body: '[]', headers: {'Content-Type' => 'application/json', 'Link' => '<https://api.zeropush.com/devices?page=10&per_page=25>; rel="last",<https://api.zeropush.com/devices?page=2&per_page=25>; rel="next"'})
     end
-    it 'should return an array' do
+    it 'returns an array' do
       response.body.class.must_equal Array
     end
-    it 'should have paginated results' do
+    it 'has paginated results' do
       response.headers["link"].must_equal '<https://api.zeropush.com/devices?page=10&per_page=25>; rel="last",<https://api.zeropush.com/devices?page=2&per_page=25>; rel="next"'
     end
   end
@@ -256,7 +256,7 @@ describe ZeroPush::Client do
     end
     let(:response){client.device('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')}
 
-    it 'should return a device hash' do
+    it 'returns a device hash' do
       response.body.class.must_equal Hash
       response.body.keys.must_equal %w[token active marked_inactive_at badge channels]
     end
@@ -268,10 +268,10 @@ describe ZeroPush::Client do
         to_return(status: 200, body: '["player-1","foobar"]', headers: {'Content-Type'=>'application/json', 'Link' => '<https://api.zeropush.com/channels?page=10&per_page=25>; rel="last",<https://api.zeropush.com/channels?page=2&per_page=25>; rel="next"'})
     end
     let(:response){client.channels}
-    it 'should return an array' do
+    it 'returns an array' do
       response.body.class.must_equal Array
     end
-    it 'should have paginated results' do
+    it 'has paginated results' do
       response.headers["link"].must_equal '<https://api.zeropush.com/channels?page=10&per_page=25>; rel="last",<https://api.zeropush.com/channels?page=2&per_page=25>; rel="next"'
     end
   end
@@ -289,7 +289,7 @@ describe ZeroPush::Client do
 
     let(:response) { client.channel('player-1') }
 
-    it 'should return a channel hash' do
+    it 'returns a channel hash' do
       response.body.class.must_equal Hash
       response.body.keys.must_equal %w[channel device_tokens]
     end
@@ -308,7 +308,7 @@ describe ZeroPush::Client do
 
     let(:response) { client.delete_channel('player-1') }
 
-    it 'should return a channel hash' do
+    it 'returns a channel hash' do
       response.body.class.must_equal Hash
       response.body.keys.must_equal %w[channel device_tokens]
     end

--- a/spec/zero_push_spec.rb
+++ b/spec/zero_push_spec.rb
@@ -6,7 +6,7 @@ describe ZeroPush do
   end
 
   describe 'using different auth_tokens' do
-    it 'should accept a hash of tokens' do
+    it 'accepts a hash of tokens' do
       ZeroPush.auth_tokens = {
         apns: 'test-apns-token',
         gcm: 'test-gcm-token'
@@ -17,14 +17,14 @@ describe ZeroPush do
   end
 
   describe '.client' do
-    it 'should return a client instance' do
+    it 'returns a client instance' do
       ZeroPush.client.class.must_equal ZeroPush::Client
     end
   end
 
   describe 'methods the module responds to' do
     [:verify_credentials, :notify, :broadcast, :subscribe, :unsubscribe, :register, :unregister, :set_badge, :inactive_tokens, :client].each do |method|
-      it "should respond to #{method}" do
+      it "responds to #{method}" do
         ZeroPush.respond_to?(method).must_equal(true)
       end
     end


### PR DESCRIPTION
Best practice for writing specs: "Use the third person in the present
tense."