### PR TITLE
Add missing delegated method + tests

### DIFF
--- a/lib/zero_push.rb
+++ b/lib/zero_push.rb
@@ -18,6 +18,7 @@ module ZeroPush
       :set_badge,
       :inactive_tokens,
       :devices,
+      :device,
       :set_device,
       :update_device,
       :channels,

--- a/spec/zero_push_spec.rb
+++ b/spec/zero_push_spec.rb
@@ -23,7 +23,7 @@ describe ZeroPush do
   end
 
   describe 'methods the module responds to' do
-    [:verify_credentials, :notify, :broadcast, :subscribe, :unsubscribe, :register, :unregister, :set_badge, :inactive_tokens, :client].each do |method|
+    [:verify_credentials, :notify, :broadcast, :subscribe, :unsubscribe, :register, :unregister, :set_badge, :inactive_tokens, :devices, :device, :set_device, :update_device, :channels, :channel, :delete_channel, :client].each do |method|
       it "responds to #{method}" do
         ZeroPush.respond_to?(method).must_equal(true)
       end


### PR DESCRIPTION
the `device` method was missing from the `def_delegators` list (and other methods were not all tested).
