### PR TITLE
ZeroPush migration to Pushwoosh notifications

### DIFF
--- a/lib/zero_push/client.rb
+++ b/lib/zero_push/client.rb
@@ -3,7 +3,7 @@ require 'faraday_middleware'
 
 module ZeroPush
   class Client
-    URL = 'https://api.zeropush.com'.freeze
+    URL = 'https://zeropush.pushwoosh.com'.freeze
 
     attr_accessor :auth_token
 


### PR DESCRIPTION
As a part of migration from zeropush to pushwoosh, we need to point api
url from https://api.zeropush.com to https://zeropush.pushwoosh.com
